### PR TITLE
Added prerequisites and BF16 model server (standalone, docker untouched).

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,3 @@
+
+Martin Weiß
+

--- a/glm-4dot7-flash/README.md
+++ b/glm-4dot7-flash/README.md
@@ -24,6 +24,61 @@ Local server deployment for GLM-4.7-Flash model with two backend options:
 
 ## Quick Start
 
+### 0. Prerequisites
+
+If you are in a freshly setup environment (like a rented dedicated server with Ubuntu), make sure the necessary software is installed:
+
+Install Huggingface-cli (in a virtual environment):
+
+First install `python3-venv`and `pip`:
+```bash
+sudo apt install python3.12-venv
+sudo apt install python3-pip
+```
+
+Now install huggingface:
+```bash
+python3 -m venv hf-env
+source hf-env/bin/activate
+pip install --upgrade pip
+pip install -U huggingface_hub
+```
+
+Quick sanity check:
+
+```bash
+hf version
+```
+
+Install `cmake`:
+```bash
+sudo apt update
+sudo apt install -y cmake
+```
+
+Verify `cmake`:
+```bash
+cmake --version
+```
+
+Install NVDIA CUDA Toolkit:
+
+```bash
+sudo apt update
+sudo apt install nvidia-cuda-toolkit
+```
+
+Verify NVDIA CUDA Toolkit installation:
+```bash
+nvcc --version
+```
+
+Install `jq` - commandline JSON processor:
+```bash
+sudo apt update
+sudo apt install jq
+```
+
 ### 1. Download Model (~18GB)
 
 ```bash
@@ -32,10 +87,22 @@ Local server deployment for GLM-4.7-Flash model with two backend options:
 
 This downloads the model to `models/` directory using HuggingFace CLI.
 
+If you want to try the largest model (and your machine meets the necessary requirements), download the BF16 version instead (~60GB):
+
+```bash
+./download_model_bf16.sh
+```
+
 ### 2. Start Server
 
 ```bash
 ./start_server.sh
+```
+
+Alternatively, if you have downloaded the BF16 model and want to run it:
+
+```bash
+./start_server_bf16.sh
 ```
 
 Server will be available at `http://127.0.0.1:11346/v1`

--- a/glm-4dot7-flash/download_model_bf16.sh
+++ b/glm-4dot7-flash/download_model_bf16.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Download GLM-4.7-Flash GGUF model using HuggingFace CLI
+# Downloads BF16 (~60GB) if not already present
+
+set -e
+
+echo "=========================================="
+echo "GLM-4.7-Flash GGUF Model Download"
+echo "=========================================="
+echo ""
+echo "Model: unsloth/GLM-4.7-Flash-GGUF"
+echo "Downloading the following quantization:"
+echo "  - BF16:    ~60GB (16-bit, higher quality)"
+echo "Local directory: models/"
+echo ""
+
+# Check if hf command exists
+if ! command -v hf &> /dev/null; then
+    echo "ERROR: 'hf' command not found!"
+    echo "Please install huggingface-cli"
+    exit 1
+fi
+
+# Create models directory if it doesn't exist
+mkdir -p models
+
+# Check and download BF16
+if [ -f "models/GLM-4.7-Flash-BF16-00001-of-00002.gguf" ]; then
+    echo "✓ BF16 already downloaded (skipping)"
+else
+    echo "Downloading BF16 (~60GB)..."
+    echo "(This will take much longer due to larger size)"
+    hf download unsloth/GLM-4.7-Flash-GGUF \
+        --include "*BF16*" \
+        --local-dir models/
+    echo "✓ BF16 download complete"
+fi
+
+echo ""
+echo "=========================================="
+echo "Download complete!"
+echo "=========================================="
+echo ""
+echo "Available models:"
+ls -lh models/GLM-4.7-Flash-*.gguf models/BF16/GLM-4.7-Flash-BF16-0000*-of-00002.gguf 2>/dev/null || echo "No models found"
+echo ""
+echo "To use BF16: Run start_server_bf16.sh"
+echo ""

--- a/glm-4dot7-flash/start_server_bf16.sh
+++ b/glm-4dot7-flash/start_server_bf16.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# GLM-4.7-Flash Server Startup Script (BF16 version)
+# Configured for tool-calling with full 202K context window
+# Port: 11346
+# Uses 8-bit quantization for higher quality
+
+set -e
+
+MODEL_PATH="models/BF16/GLM-4.7-Flash-BF16-00001-of-00002.gguf"
+SERVER_BIN="llama.cpp/build/bin/llama-server"
+
+# Check if model exists
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "ERROR: Model not found at $MODEL_PATH"
+    echo "Please run ./download_model.sh first"
+    exit 1
+fi
+
+# Check if server binary exists
+if [ ! -f "$SERVER_BIN" ]; then
+    echo "ERROR: llama-server not found at $SERVER_BIN"
+    echo "Please run ./build.sh first"
+    exit 1
+fi
+
+echo "=========================================="
+echo "GLM-4.7-Flash Server (BF16)"
+echo "=========================================="
+echo "Model: $MODEL_PATH"
+echo "Quantization: 16-bit (higher quality)"
+echo "Port: 11346"
+echo "Context: 202,752 tokens (full)"
+echo "Mode: Tool-calling optimized"
+echo "=========================================="
+echo ""
+echo "Starting server..."
+echo "API endpoint: http://0.0.0.0:11346/v1"
+echo "Accessible from network at: http://hordak:11346/v1"
+echo ""
+
+./$SERVER_BIN \
+    --model "$MODEL_PATH" \
+    --alias "unsloth/GLM-4.7-Flash" \
+    --host 0.0.0.0 \
+    --threads -1 \
+    --fit on \
+    --temp 0.7 \
+    --top-p 1.0 \
+    --min-p 0.01 \
+    --ctx-size 202752 \
+    --port 11346 \
+    --jinja \
+    --repeat-penalty 1.0


### PR DESCRIPTION
Added prerequisites (software to be installed) for easier setup.
Added script to download BF16 model and start server.
(Only standalone version, didn't succeed in running the docker based version :-( )